### PR TITLE
Adds OSGi Support

### DIFF
--- a/fastods/src/main/java/com/github/jferard/fastods/AbstractTableCell.java
+++ b/fastods/src/main/java/com/github/jferard/fastods/AbstractTableCell.java
@@ -3,7 +3,6 @@ package com.github.jferard.fastods;
 import com.github.jferard.fastods.attribute.Length;
 import com.github.jferard.fastods.datastyle.DataStyle;
 import com.github.jferard.fastods.style.TableCellStyle;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.util.Calendar;
@@ -12,164 +11,164 @@ import java.util.Date;
 /**
  * An abstract class to ease the implementation of `WritableTableCell`. The method 
  * `appendXMLToTableRow` should be implemented. All other methods will throw a 
- * `NotImplementedException`.
+ * `UnsupportedOperationException`.
  */
 public abstract class AbstractTableCell implements WritableTableCell {
     @Override
     public void markRowsSpanned(final int n) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setBooleanValue(final boolean value) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setCellValue(final CellValue value) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setCurrencyValue(final float value, final String currency) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setCurrencyValue(final int value, final String currency) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setCurrencyValue(final Number value, final String currency) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setDateValue(final Calendar cal) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setDateValue(final Date date) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setFloatValue(final float value) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setFloatValue(final int value) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setFloatValue(final Number value) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setPercentageValue(final float value) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setPercentageValue(final int value) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setPercentageValue(final Number value) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setStringValue(final String value) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setStyle(final TableCellStyle style) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setTimeValue(final long timeInMillis) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setTimeValue(final long years, final long months, final long days, final long hours, final long minutes,
                              final double seconds) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setNegTimeValue(final long years, final long months, final long days, final long hours, final long minutes,
                                 final double seconds) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setTooltip(final String tooltipText) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setTooltip(final String tooltipText, final Length width, final Length height, final boolean visible) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setTooltip(final Tooltip tooltip) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setFormula(final String formula) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean isCovered() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setCovered() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setColumnsSpanned(final int n) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void markColumnsSpanned(final int n) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setRowsSpanned(final int n) throws IOException {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setVoidValue() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setMatrixFormula(final String formula) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setMatrixFormula(final String formula, final int matrixRowsSpanned, final int matrixColumnsSpanned) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -179,21 +178,21 @@ public abstract class AbstractTableCell implements WritableTableCell {
 
     @Override
     public void setText(final Text text) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setCellMerge(final int rowMerge, final int columnMerge) throws IOException {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setDataStyle(final DataStyle dataStyle) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public int colIndex() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,15 @@
                 <artifactId>maven-release-plugin</artifactId>
             </plugin>
             <plugin>
+			    <groupId>biz.aQute.bnd</groupId>
+			    <artifactId>bnd-maven-plugin</artifactId>
+			    <configuration>
+			    	<bnd><![CDATA[
+		            	Export-Package: com.github.jferard.fastods.*
+			    	]]></bnd>
+			    </configuration>
+			</plugin>
+            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
             </plugin>
@@ -163,6 +172,18 @@
                         <fork>true</fork>
                     </configuration>
                 </plugin>
+       			<plugin>
+				    <groupId>biz.aQute.bnd</groupId>
+				    <artifactId>bnd-maven-plugin</artifactId>
+				    <version>5.0.1</version>
+				    <executions>
+				        <execution>
+				            <goals>
+				                <goal>bnd-process</goal>
+				            </goals>
+				        </execution>
+				    </executions>
+				</plugin>
 
                 <!-- for OSSRH releases -->
                 <plugin>
@@ -224,7 +245,16 @@
                         </execution>
                     </executions>
                 </plugin>
-
+				<plugin>
+				    <groupId>org.apache.maven.plugins</groupId>
+				    <artifactId>maven-jar-plugin</artifactId>
+				    <version>3.2.0</version>
+				    <configuration>
+				        <archive>
+				            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+				        </archive>
+				    </configuration>
+				</plugin>
                 <!-- release -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
While I was on it, I saw the import of the NoImplementationException and took the liberty of replacing it with the UnsupportedOperationException. Using such internal java Classes binds the library to an oracle JDK and can cause problems with higher java Versions, where they may already have removed it.

One sidenote for the future:

OSGi makes a distinction between internal  packages and exported API. The CData section configures it to Mark each Package that fits com.github.jferard.fastods.* as public API. So you are fine, if you add new packages that fit this schema. If you add new Packages like e.g. com.github.jferard.common, and they are not only used internally, it would be great if you would add them with a comma as separator example would be:

```
<![CDATA[
   Export-Package: com.github.jferard.fastods.*, com.github.jferard.common
]]>
```
or (if you want a line break)
```
<![CDATA[
    Export-Package: com.github.jferard.fastods.*, \
        com.github.jferard.common
]]>
```