### PR TITLE
PreambleAppender#appendColumns : prevent systematic table:table-column=1024

### DIFF
--- a/fastods-crypto/pom.xml
+++ b/fastods-crypto/pom.xml
@@ -55,6 +55,22 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/fastods/src/main/java/com/github/jferard/fastods/PreambleAppender.java
+++ b/fastods/src/main/java/com/github/jferard/fastods/PreambleAppender.java
@@ -72,7 +72,7 @@ public class PreambleAppender {
         final Iterator<TableColumnImpl> iterator = this.model.getColumns().iterator();
         if (!iterator.hasNext()) {
             TableColumnImpl.DEFAULT_TABLE_COLUMN
-                    .appendXMLToTable(xmlUtil, appendable, MAX_COLUMN_COUNT);
+                    .appendXMLToTable(xmlUtil, appendable, this.model.getColumnCapacity());
             return;
         }
 

--- a/fastods/src/main/java/com/github/jferard/fastods/TableModel.java
+++ b/fastods/src/main/java/com/github/jferard/fastods/TableModel.java
@@ -683,4 +683,8 @@ class TableModel {
     public int getHeaderColumnsCount() {
         return this.headerColumnsCount;
     }
+
+    public int getColumnCapacity() {
+        return this.columnCapacity;
+    }
 }

--- a/fastods/src/test/java/com/github/jferard/fastods/PreambleAppenderTest.java
+++ b/fastods/src/test/java/com/github/jferard/fastods/PreambleAppenderTest.java
@@ -84,13 +84,15 @@ public class PreambleAppenderTest {
         PowerMock.resetAll();
         EasyMock.expect(this.tm.getColumns())
                 .andReturn(FastFullList.<TableColumnImpl>newList());
+        EasyMock.expect(this.tm.getColumnCapacity())
+                .andReturn(42);
 
         PowerMock.replayAll();
         final StringBuilder sb = new StringBuilder();
         this.preambleAppender.appendColumns(this.xmlUtil, sb);
         DomTester.assertEquals(
                         "<table:table-column table:style-name=\"co1\"" +
-                        " table:number-columns-repeated=\"1024\" " +
+                        " table:number-columns-repeated=\"42\" " +
                         "table:default-cell-style-name=\"Default\"/>", sb.toString());
         PowerMock.verifyAll();
     }

--- a/fastods/src/test/java/com/github/jferard/fastods/TableAppenderTest.java
+++ b/fastods/src/test/java/com/github/jferard/fastods/TableAppenderTest.java
@@ -98,13 +98,14 @@ public class TableAppenderTest {
                         appendable.append("FOO");
                     }
                 }));
+        EasyMock.expect(this.tm.getColumnCapacity()).andReturn(100);
 
         PowerMock.replayAll();
         this.assertPreambleXMLEquals(
                 "<table:table table:name=\"table1\" table:style-name=\"table-style1\" " +
                         "table:print=\"false\"><office:forms form:automatic-focus=\"false\" " +
                         "form:apply-design-mode=\"false\">FOO</office:forms><table:table-column " +
-                        "table:style-name=\"co1\" table:number-columns-repeated=\"1024\" " +
+                        "table:style-name=\"co1\" table:number-columns-repeated=\"100\" " +
                         "table:default-cell-style-name=\"Default\"/>");
 
         PowerMock.verifyAll();
@@ -125,7 +126,8 @@ public class TableAppenderTest {
         EasyMock.expect(this.tm.getColumns())
                 .andReturn(FastFullList.<TableColumnImpl>newListWithCapacity(1));
         EasyMock.expect(this.tm.getForms()).andReturn(Collections.<XMLConvertible>emptyList());
-
+        EasyMock.expect(this.tm.getColumnCapacity()).andReturn(100);
+        
         PowerMock.replayAll();
         this.assertPreambleXMLEquals(
                 "<table:table table:name=\"table1\" table:style-name=\"table-style1\" " +
@@ -136,7 +138,7 @@ public class TableAppenderTest {
                         "xlink:show=\"embed\" xlink:actuate=\"onLoad\"/>" +
                         "</draw:frame></table:shapes>" +
                         "<table:table-column table:style-name=\"co1\" " +
-                        "table:number-columns-repeated=\"1024\" " +
+                        "table:number-columns-repeated=\"100\" " +
                         "table:default-cell-style-name=\"Default\"/>"
         );
 
@@ -281,6 +283,7 @@ public class TableAppenderTest {
         EasyMock.expect(this.tm.getShapes()).andReturn(Collections.<Shape>emptyList());
         EasyMock.expect(this.tm.getForms()).andReturn(Collections.<XMLConvertible>emptyList());
         EasyMock.expect(this.tm.getHeaderRowsCount()).andReturn(0);
+        EasyMock.expect(this.tm.getColumnCapacity()).andReturn(100);
 
         PowerMock.replayAll();
         this.tableAppender.appendAllAvailableRows(this.xmlUtil, sb);
@@ -289,7 +292,7 @@ public class TableAppenderTest {
         sb.append("</table:table>");
         DomTester.assertEquals("<table:table table:name=\"tb\" table:style-name=\"tb-style\" " +
                 "table:print=\"false\"><table:table-column " +
-                "table:style-name=\"co1\" " + "table:number-columns-repeated=\"1024\" " +
+                "table:style-name=\"co1\" " + "table:number-columns-repeated=\"100\" " +
                 "table:default-cell-style-name=\"Default\"/></table:table>", sb.toString());
     }
 
@@ -313,6 +316,7 @@ public class TableAppenderTest {
         EasyMock.expect(this.tm.getForms()).andReturn(
                 Collections.<XMLConvertible>emptyList()).times(2);
         EasyMock.expect(this.tm.getHeaderRowsCount()).andReturn(0).times(2);
+        EasyMock.expect(this.tm.getColumnCapacity()).andReturn(100).times(2);
 
         PowerMock.replayAll();
         this.tableAppender.appendXMLToContentEntry(this.xmlUtil, sb1);
@@ -349,6 +353,7 @@ public class TableAppenderTest {
         EasyMock.expect(this.tm.getTableRow(3)).andReturn(tr3);
         EasyMock.expect(this.tm.getTableRow(4)).andReturn(tr4);
         EasyMock.expect(this.tm.getTableRowsUsedSize()).andReturn(5);
+        EasyMock.expect(this.tm.getColumnCapacity()).andReturn(100);
 
         PowerMock.replayAll();
         this.tableAppender.appendXMLToContentEntry(this.xmlUtil, sb);
@@ -358,7 +363,7 @@ public class TableAppenderTest {
                 "table:style-name=\"tb-style\" " +
                 "table:print=\"false\">" +
                 "<table:table-column table:style-name=\"co1\" " +
-                "table:number-columns-repeated=\"1024\" " +
+                "table:number-columns-repeated=\"100\" " +
                 "table:default-cell-style-name=\"Default\"/>" +
                 "<table:table-row table:style-name=\"tr0\">" +
                 "<table:table-cell/>" +
@@ -402,6 +407,7 @@ public class TableAppenderTest {
         EasyMock.expect(this.tm.getTableRow(3)).andReturn(tr3);
         EasyMock.expect(this.tm.getTableRow(4)).andReturn(tr4);
         EasyMock.expect(this.tm.getTableRowsUsedSize()).andReturn(5);
+        EasyMock.expect(this.tm.getColumnCapacity()).andReturn(100);
 
         PowerMock.replayAll();
         this.tableAppender.appendXMLToContentEntry(this.xmlUtil, sb);
@@ -411,7 +417,7 @@ public class TableAppenderTest {
                 "table:style-name=\"tb-style\" " +
                 "table:print=\"false\">" +
                 "<table:table-column table:style-name=\"co1\" " +
-                "table:number-columns-repeated=\"1024\" " +
+                "table:number-columns-repeated=\"100\" " +
                 "table:default-cell-style-name=\"Default\"/>" +
                 "<table:table-header-rows>" +
                 "<table:table-row table:style-name=\"tr0\">" +
@@ -505,6 +511,7 @@ public class TableAppenderTest {
         EasyMock.expect(this.tm.getTableRow(0)).andReturn(tr0);
         EasyMock.expect(this.tm.getTableRow(1)).andReturn(tr1);
         EasyMock.expect(this.tm.getTableRowsUsedSize()).andReturn(2);
+        EasyMock.expect(this.tm.getColumnCapacity()).andReturn(100);
 
         PowerMock.replayAll();
         this.tableAppender.appendSomeAvailableRowsFrom(this.xmlUtil, sb, 0);
@@ -515,7 +522,7 @@ public class TableAppenderTest {
                 "<table:table table:name=\"table\" table:style-name=\"style\" " +
                         "table:print=\"false\">" +
                         "<table:table-column table:style-name=\"co1\" " +
-                        "table:number-columns-repeated=\"1024\" " +
+                        "table:number-columns-repeated=\"100\" " +
                         "table:default-cell-style-name=\"Default\"/>" +
                         "<table:table-row table:style-name=\"tr0\">" +
                         "<table:table-cell/>" +
@@ -549,6 +556,7 @@ public class TableAppenderTest {
         EasyMock.expect(this.tm.getTableRow(3)).andReturn(null);
         EasyMock.expect(this.tm.getTableRow(4)).andReturn(tr0);
         EasyMock.expect(this.tm.getTableRowsUsedSize()).andReturn(5).anyTimes();
+        EasyMock.expect(this.tm.getColumnCapacity()).andReturn(100);
 
         PowerMock.replayAll();
         this.tableAppender.appendXMLToContentEntry(this.xmlUtil, sb);
@@ -558,7 +566,7 @@ public class TableAppenderTest {
                 "table:style-name=\"tb-style\" " +
                 "table:print=\"false\">" +
                 "<table:table-column table:style-name=\"co1\" " +
-                "  table:number-columns-repeated=\"1024\" " +
+                "  table:number-columns-repeated=\"100\" " +
                 "  table:default-cell-style-name=\"Default\"/>" +
                 "<table:table-header-rows>" +
                 "<table:table-row table:style-name=\"tr0\">" +
@@ -658,6 +666,7 @@ public class TableAppenderTest {
         EasyMock.expect(this.tm.getShapes()).andReturn(Collections.<Shape>emptyList());
         EasyMock.expect(this.tm.getColumns())
                 .andReturn(FastFullList.<TableColumnImpl>newListWithCapacity(1));
+        EasyMock.expect(this.tm.getColumnCapacity()).andReturn(100);
 
         PowerMock.replayAll();
         this.tableAppender.appendOpenTagAndPreamble(this.xmlUtil, sb);
@@ -670,7 +679,7 @@ public class TableAppenderTest {
                         "table:protected=\"true\" table:protection-key=\"a\" " +
                         "table:protection-key-digest-algorithm=\"b\" attr=\"value\">" +
                         "<table:table-column table:style-name=\"co1\" " +
-                        "table:number-columns-repeated=\"1024\" " +
+                        "table:number-columns-repeated=\"100\" " +
                         "table:default-cell-style-name=\"Default\"/></table:table>",
                 sb.toString());
     }

--- a/fastods/src/test/java/com/github/jferard/fastods/TableTest.java
+++ b/fastods/src/test/java/com/github/jferard/fastods/TableTest.java
@@ -197,7 +197,7 @@ public class TableTest {
         this.assertTableXMLEquals("<table:table table:name=\"my_table\" table:style-name=\"ta1\" " +
                 "table:print=\"false\">" +
                 "<table:table-column table:style-name=\"co1\" " +
-                "table:number-columns-repeated=\"1024\" " +
+                "table:number-columns-repeated=\"100\" " +
                 "table:default-cell-style-name=\"Default\"/>" + "<table:table-row " +
                 "table:number-rows-repeated=\"10\" table:style-name=\"ro1\">" +
                 "<table:table-cell/>" + "</table:table-row>" +
@@ -427,7 +427,7 @@ public class TableTest {
         PowerMock.verifyAll();
         DomTester.assertEquals("<table:table table:name=\"my_table\" table:style-name=\"ta1\" " +
                         "table:print=\"false\"><table:table-column " +
-                        "table:style-name=\"co1\" " + "table:number-columns-repeated=\"1024\" " +
+                        "table:style-name=\"co1\" " + "table:number-columns-repeated=\"100\" " +
                         "table:default-cell-style-name=\"Default\"/><table:table-row " +
                         "table:style-name=\"ro1\"><table:table-cell office:value-type=\"boolean\"" +
                         " office:boolean-value=\"true\"/></table:table-row></table:table>",

--- a/fastods/src/test/java/com/github/jferard/fastods/odselement/ContentElementTest.java
+++ b/fastods/src/test/java/com/github/jferard/fastods/odselement/ContentElementTest.java
@@ -387,7 +387,7 @@ public class ContentElementTest {
                         "<office:spreadsheet>" +
                         "<table:table table:name=\"t\" table:style-name=\"ta1\" " +
                         "table:print=\"false\"><table:table-column table:style-name=\"co1\" " +
-                        "table:number-columns-repeated=\"1024\" " +
+                        "table:number-columns-repeated=\"100\" " +
                         "table:default-cell-style-name=\"Default\"/>" +
                         "<table:table-row><table:table-cell/></table:table-row>" +
                         "</table:table>" +


### PR DESCRIPTION
When an ODS contains only one or few columns, it is not desirable to export the constant MAX_COLUMN_COUNT=1024 as attribute number-columns-repeated. 
ODS readers (like [SODS](https://github.com/miachm/SODS)) will consider a generated file with 2 columns contains "rows * 1024" cells wheras it contains only "rows * 2" cells.

The TableModel#columnCapacity knows the initial columnCapacity. Using this value is more accurate.